### PR TITLE
Introduces build metadata system

### DIFF
--- a/Foundation/src/main/java/creativitium/revolution/foundation/Foundation.java
+++ b/Foundation/src/main/java/creativitium/revolution/foundation/Foundation.java
@@ -3,6 +3,7 @@ package creativitium.revolution.foundation;
 import creativitium.revolution.foundation.base.MessageService;
 import creativitium.revolution.foundation.base.PlayerDataService;
 import creativitium.revolution.foundation.hook.VaultHook;
+import creativitium.revolution.foundation.utilities.BuildVersion;
 import lombok.Getter;
 import net.kyori.adventure.key.Key;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -36,6 +37,22 @@ public class Foundation extends JavaPlugin
     {
         instance = this;
         commandLoader = new CommandLoader();
+
+        BuildVersion.getVersion(this).ifPresent(version ->
+        {
+            if (version.isDevelopmentBuild())
+            {
+                getSLF4JLogger().warn("You are currently using a development build of Foundation. Assuming that this is a development environment, here is some advice:");
+                getSLF4JLogger().warn("- Foundation should remain fundamentally the same and should not have any drastic changes. If you make such changes anyways, either try to keep the original functions around to retain backwards compatibility or update the plugins that relied on the older functionality");
+                getSLF4JLogger().warn("- If you make changes to other subprojects that include changes to Foundation itself, don't forget to replace Foundation as well when you go to run it on a test server");
+                getSLF4JLogger().warn("- Due to how the custom message system works, there is no \"automatic updates\" functionality for messages.json and prefixes.json - you will need to regenerate the files by deleting the files from their relevant folders and using /messages reload");
+                getSLF4JLogger().warn("- Do not mix builds from different branches together as this could cause stability/compatibility issues");
+                getSLF4JLogger().warn("- Make sure you don't have multiple versions of the same plugin installed as this will cause all kinds of issues");
+                getSLF4JLogger().warn("- Do not use builds intended for development environments in production environments as this could cause stability/compatibility/security issues");
+                getSLF4JLogger().warn("- If you are seeing this message in a production environment even though you're sure you shouldn't be, make sure that the current branch is set to \"main\" and that any changes you made have been committed and then try compiling again");
+                getSlf4jLogger().warn("With all that said, here are the build details: \n{}", version);
+            }
+        });
     }
 
     @Override

--- a/Foundation/src/main/java/creativitium/revolution/foundation/base/MessageService.java
+++ b/Foundation/src/main/java/creativitium/revolution/foundation/base/MessageService.java
@@ -24,7 +24,7 @@ public class MessageService extends RService
     private final Map<String, String> prefixes = new HashMap<>();
     @Getter
     private final Map<String, String> messages = new HashMap<>();
-    //--
+    @Getter
     private final List<Plugin> externalPlugins = new ArrayList<>();
 
     @Override

--- a/Foundation/src/main/java/creativitium/revolution/foundation/commands/RevolutionCmd.java
+++ b/Foundation/src/main/java/creativitium/revolution/foundation/commands/RevolutionCmd.java
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2024 videogamesm12
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package creativitium.revolution.foundation.commands;
 
 import creativitium.revolution.foundation.command.CommandParameters;

--- a/Foundation/src/main/java/creativitium/revolution/foundation/commands/RevolutionCmd.java
+++ b/Foundation/src/main/java/creativitium/revolution/foundation/commands/RevolutionCmd.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 videogamesm12
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package creativitium.revolution.foundation.commands;
+
+import creativitium.revolution.foundation.command.CommandParameters;
+import creativitium.revolution.foundation.command.RCommand;
+import creativitium.revolution.foundation.command.SourceType;
+import creativitium.revolution.foundation.utilities.BuildVersion;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+@CommandParameters(name = "revolution",
+        description = "Display information about Revolution.",
+        usage = "/revolution",
+        aliases = {"rvl"},
+        permission = "foundation.command.revolution",
+        source = SourceType.BOTH)
+public class RevolutionCmd extends RCommand
+{
+    @Override
+    public boolean run(CommandSender sender, Player playerSender, String commandLabel, String[] args)
+    {
+        if (args.length != 0) return false;
+
+        msg(sender, "foundation.command.revolution.info.introduction",
+                Placeholder.parsed("version", foundation.getDescription().getVersion()));
+
+        msg(sender, "foundation.command.revolution.info.build_info", Placeholder.component("plugins",
+                Component.join(JoinConfiguration.commas(true),
+                        foundation.getMessageService().getExternalPlugins().stream().map(pl ->
+                        {
+                            final Optional<BuildVersion> buildVersion = BuildVersion.getVersion(pl);
+
+                            return getMessage("foundation.command.revolution.info.build_info.plugin",
+                                    TagResolver.resolver("status_color", Tag.styling(text -> text.color(pl.isEnabled() ? NamedTextColor.GREEN : NamedTextColor.RED))),
+                                    Placeholder.parsed("name", pl.getName()),
+                                    Placeholder.parsed("stringified_build_info", buildVersion.isPresent() ? buildVersion.get().toString() : ""),
+                                    Placeholder.component("formatted_build_info", buildVersion.isPresent() ? getMessage("foundation.command.revolution.info.build_info.format", buildVersion.get().toPlaceholders()) : getMessage("foundation.command.revolution.info.build_info.unable_to_find_build_metadata")));
+                        }).toList())));
+
+        return true;
+    }
+
+    @Override
+    public @NotNull Plugin getPlugin()
+    {
+        return foundation;
+    }
+}

--- a/Foundation/src/main/java/creativitium/revolution/foundation/utilities/BuildVersion.java
+++ b/Foundation/src/main/java/creativitium/revolution/foundation/utilities/BuildVersion.java
@@ -1,0 +1,76 @@
+package creativitium.revolution.foundation.utilities;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import org.bukkit.plugin.Plugin;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Getter
+public class BuildVersion
+{
+    private static final Gson GSON = new Gson();
+    private static final Map<Plugin, BuildVersion> cache = new HashMap<>();
+
+    @SerializedName("git.branch")
+    private String branch;
+    @SerializedName("git.build.time")
+    private String buildTime;
+    @SerializedName("git.commit.id")
+    private String commitId;
+    @SerializedName("git.commit.time")
+    private String commitTime;
+    @SerializedName("git.dirty")
+    private boolean dirty;
+
+    public boolean isDevelopmentBuild()
+    {
+        return dirty || !branch.equalsIgnoreCase("main");
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("===== BUILD DETAILS =====\n - Branch: %s\n - Build Date: %s\n - Commit: %s\n - Commit Date: %s\n - Changes Committed: %s\n=========================",
+                branch, buildTime, commitId, commitTime, !dirty);
+    }
+
+    public TagResolver.Single[] toPlaceholders()
+    {
+        return new TagResolver.Single[] {
+                Placeholder.parsed("branch", branch),
+                Placeholder.parsed("build_date", buildTime),
+                Placeholder.parsed("commit", commitId),
+                Placeholder.parsed("commit_date", commitTime),
+                Placeholder.parsed("changes_committed", String.valueOf(!dirty))};
+    }
+
+    public static Optional<BuildVersion> getVersion(Plugin plugin)
+    {
+        // Avoid pulling the data if we already have it cached
+        if (cache.containsKey(plugin))
+        {
+            return Optional.ofNullable(cache.get(plugin));
+        }
+
+        final InputStream resource = plugin.getResource("build.json");
+
+        if (resource == null)
+        {
+            cache.put(plugin, null);
+            return Optional.empty();
+        }
+
+        final BuildVersion result = GSON.fromJson(new InputStreamReader(resource), BuildVersion.class);
+        cache.put(plugin, result);
+
+        return Optional.ofNullable(result);
+    }
+}

--- a/Foundation/src/main/resources/messages.json
+++ b/Foundation/src/main/resources/messages.json
@@ -17,5 +17,11 @@
 
   "revolution.command.messages.reload": "<success>The messages system has been reloaded.",
   "revolution.command.messages.stats": "<info>There are currently <white><prefixcount> <gray>prefixes and <white><messagescount> <gray>messages loaded.",
-  "revolution.command.messages.test": "Output:<newline><output>"
+  "revolution.command.messages.test": "Output:<newline><output>",
+
+  "foundation.command.revolution.info.introduction": "<info>This server is running <white>Revolution</white> version <white><version></white>.",
+  "foundation.command.revolution.info.build_info": "<info>Currently installed Revolution plugins: <plugins>",
+  "foundation.command.revolution.info.build_info.format": "<white><b>Build Information:</b><newline><gray>Branch: <white><branch></white><newline>Build Date: <white><build_date></white><newline>Commit ID: <white><commit></white><newline>Commit Date: <white><commit_date></white><newline>Changes Committed: <white><changes_committed></white>",
+  "foundation.command.revolution.info.build_info.plugin": "<white><hover:show_text:'<formatted_build_info>'><click:copy_to_clipboard:'<stringified_build_info>'><name></click></hover></white>",
+  "foundation.command.revolution.info.build_info.unable_to_find_build_metadata": "<red>Unable to find build metadata for this plugin."
 }

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,31 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/build.json</generateGitPropertiesFilename>
+                    <format>json</format>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>git.branch</includeOnlyProperty>
+                        <includeOnlyProperty>git.build.time</includeOnlyProperty>
+                        <includeOnlyProperty>git.commit.id</includeOnlyProperty>
+                        <includeOnlyProperty>git.commit.time</includeOnlyProperty>
+                        <includeOnlyProperty>git.dirty</includeOnlyProperty>
+                    </includeOnlyProperties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>


### PR DESCRIPTION
All subprojects under the Revolution umbrella will now contain a build metadata file that is automatically generated during the compilation process.

This change offers three noteworthy benefits:
- It is possible to use factors like the branch and whether or not the changes have been committed to determine if the build is intended for a development environment. In the future, this may or may not be expanded upon.
- Timestamps of the latest commit along with when the build was compiled to estimate how far into the development process a particular build was
- Server owners/testers can use the /revolution command to obtain useful information about their build of a particular subproject if they run into issues and need to report them